### PR TITLE
3.0.1 - iOS icon bug

### DIFF
--- a/src/templates/init/index.html
+++ b/src/templates/init/index.html
@@ -42,7 +42,12 @@
 ################################################################################
 -->
   {% for src in assets.JS %}
-	<script src="{{src}}"></script>{% endfor %}
+    {% if 'fontawesome' in src %}
+        <script src="{{src}}" crossorigin="anonymous"></script>
+    {% else %}
+        <script src="{{src}}"></script>
+    {% endif %}
+  {% endfor %}
 
   </head>
 

--- a/src/templates/init/index.html
+++ b/src/templates/init/index.html
@@ -43,6 +43,7 @@
 -->
   {% for src in assets.JS %}
     {% if 'fontawesome' in src %}
+	<!-- fontawesome icons not loading correctly on iOS -->
         <script src="{{src}}" crossorigin="anonymous"></script>
     {% else %}
         <script src="{{src}}"></script>


### PR DESCRIPTION
## Summary
- add crossorigin for Font Awesome kit so icons render correctly on mobile

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687fbe733754832a98455efa794e121f